### PR TITLE
Add support for source_code_management_uri in new engagements

### DIFF
--- a/dd_import/dd_api.py
+++ b/dd_import/dd_api.py
@@ -127,6 +127,8 @@ class Api:
                    'target_end': self.environment.engagement_target_end,
                    'engagement_type': 'CI/CD',
                    'status': 'In Progress'}
+        if self.environment.source_code_management_uri is not None:
+            payload['source_code_management_uri'] = self.environment.source_code_management_uri
         r = requests.post(self.engagement_url,
                           headers=self.headers,
                           data=json.dumps(payload),

--- a/unittests/test_api.py
+++ b/unittests/test_api.py
@@ -235,6 +235,28 @@ class TestApi(TestCase):
         response.raise_for_status.assert_called_once()
 
     @patch('dd_import.environment.Environment')
+    @patch('requests.post')
+    @patch.dict('os.environ', {'DD_URL': 'https://example.com',
+                               'DD_API_KEY': 'api_key',
+                               'DD_ENGAGEMENT_NAME': 'engagement',
+                               'DD_SOURCE_CODE_MANAGEMENT_URI': 'https://github.com/MyOrg/MyProject/tree/main'})
+    def test_new_engagement_with_source_code_management_uri(self, mockPost, mockEnv):
+        response = Mock(spec=Response)
+        response.status_code = 200
+        response.text = '{\"id\": 3}'
+        mockPost.return_value = response
+
+        api = Api()
+        id = api.new_engagement(self.product_id)
+
+        self.assertEqual(id, self.engagement_id)
+        today = datetime.date.today().isoformat()
+        url = 'https://example.com/api/v2/engagements/'
+        payload = f'{{"name": "engagement", "product": 2, "target_start": "{today}", "target_end": "2999-12-31", "engagement_type": "CI/CD", "status": "In Progress", "source_code_management_uri": "https://github.com/MyOrg/MyProject/tree/main"}}'
+        mockPost.assert_called_once_with(url, headers=self.header, data=payload, verify=True)
+        response.raise_for_status.assert_called_once()
+
+    @patch('dd_import.environment.Environment')
     @patch('requests.patch')
     @patch.dict('os.environ', {'DD_URL': 'https://example.com',
                                'DD_API_KEY': 'api_key',


### PR DESCRIPTION
A follow-up to https://github.com/MaibornWolff/dd-import/pull/100

Add support for source_code_management_uri for the new engagements